### PR TITLE
[Fix] Increment year in copyright notice

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -53,7 +53,7 @@ params:
   containerMaxWidth: 850px
   dateFormat: January 2, 2006
 #  homeText: Welcome to the Vanilla theme demo. Have a look around. Maybe even eat some ice cream. NOTE: This is now fufilled via _index.md in /content
-  footerText: "[About](/about) • [Disclaimers](/disclaimers) • [License](https://creativecommons.org/licenses/by-sa/4.0/) | Copyright © Josh Atkinson MMXXI"
+  footerText: "[About](/about) • [Disclaimers](/disclaimers) • [License](https://creativecommons.org/licenses/by-sa/4.0/) | Copyright © Josh Atkinson MMXXII"
   hideFooter: false
   katex: true
 


### PR DESCRIPTION
## What does it do?

This PR fixes the incorrect year in the copyright notice, incrementing it by 1 to match the current calendar year.

## Breaking changes?

None.